### PR TITLE
Drop --allow-eol escape hatch

### DIFF
--- a/mclazy.py
+++ b/mclazy.py
@@ -202,7 +202,6 @@ def main():
     # read defaults from command line arguments
     parser = argparse.ArgumentParser(description='Automatically build Fedora packages for a GNOME release')
     parser.add_argument('fedora_branch', metavar='BRANCH', help='The fedora release to target')
-    parser.add_argument('--allow-eol', action='store_true', help='Allow operation on EOL branches')
     parser.add_argument('--no-simulate', action='store_false', dest='simulate', help='Push the changes this tool makes')
     parser.add_argument('--check-installed', action='store_true', help='Check installed version against built version')
     parser.add_argument('--relax-version-checks', action='store_true', help='Relax checks on the version numbering')
@@ -243,7 +242,7 @@ def main():
         return
     args.fedora_branch = branches[args.fedora_branch].name
 
-    if branches[args.fedora_branch].eol and not args.allow_eol:
+    if branches[args.fedora_branch].eol:
         print_fail(f"Branch {args.fedora_branch} is EOL")
         return
 


### PR DESCRIPTION
> It never makes sense to allow operating on an EOL branch, so we don't
need an override flag

- Michael, in https://github.com/mcatanzaro/mclazy/pull/5#discussion_r2611390687