### PR TITLE
Remove papers from mclazy

### DIFF
--- a/modules.xml
+++ b/modules.xml
@@ -534,7 +534,6 @@
     <release version="f42">2.57</release>
     <release version="f43">2.57</release>
   </project>
-  <project name="papers"/>
   <project name="polari"/>
   <project name="ptyxis"/>
   <project name="pyatspi">


### PR DESCRIPTION
Papers requires manual intervention that mclazy cannot do. Thus, it must be updated manually

Fixes #10